### PR TITLE
Domain name lookup is no longer transactional

### DIFF
--- a/TaggableGrailsPlugin.groovy
+++ b/TaggableGrailsPlugin.groovy
@@ -21,7 +21,7 @@ import grails.util.*
  * @author Graeme Rocher
  */
 class TaggableGrailsPlugin {
-    def version = "1.1.0"
+    def version = "1.1.2"
     def grailsVersion = "2.3 > *"
     def license = 'APACHE'
     def pluginExcludes = [
@@ -140,7 +140,7 @@ A plugin that adds a generic mechanism for tagging data.
                             def clazz = delegate
                             TagLink.withCriteria {
                                 projections { tag { distinct "name" } }
-                                'in'('type', tagService.domainClassFamilies[clazz.name])
+                                'in'('type', tagService.getTaggablePropertyName(clazz.name))
                                 cache true
                             }
                         }
@@ -148,7 +148,7 @@ A plugin that adds a generic mechanism for tagging data.
                             def clazz = delegate
                             TagLink.createCriteria().get {
                                 projections { tag { countDistinct "name" } }
-                                'in'('type', tagService.domainClassFamilies[clazz.name])
+                                'in'('type', tagService.getTaggablePropertyName(clazz.name))
                                 cache true
                             }                            
                         }
@@ -208,7 +208,7 @@ A plugin that adds a generic mechanism for tagging data.
                             def clazz = delegate
                             TagLink.withCriteria {
                                 projections { tag { distinct "name" } }
-                                'in'('type', tagService.domainClassFamilies[clazz.name])
+                                'in'('type', tagService.getTaggablePropertyName(clazz.name))
                                 cache true
                                 tag(criteria)
 
@@ -231,7 +231,7 @@ A plugin that adds a generic mechanism for tagging data.
     }
 
     private getTagLinks(tagService, obj) {
-        TagLink.findAllByTagRefAndTypeInList(obj.id, tagService.domainClassFamilies[obj.class.name], [cache:true])        
+        TagLink.findAllByTagRefAndTypeInList(obj.id, tagService.getTaggablePropertyName(obj.class.name), [cache:true])
     }
     
     def onChange = { event ->
@@ -247,7 +247,7 @@ A plugin that adds a generic mechanism for tagging data.
                 tag {
                     eq 'name', tagName                            
                 }                
-                'in'('type', tagService.domainClassFamilies[className])
+                'in'('type', tagService.getTaggablePropertyName(className))
                 cache true
             }
             

--- a/TaggableGrailsPlugin.groovy
+++ b/TaggableGrailsPlugin.groovy
@@ -21,7 +21,8 @@ import grails.util.*
  * @author Graeme Rocher
  */
 class TaggableGrailsPlugin {
-    def version = "1.1.2"
+    def groupId = 'org.icescrum'
+    def version = "1.1.3"
     def grailsVersion = "2.3 > *"
     def license = 'APACHE'
     def pluginExcludes = [
@@ -202,6 +203,25 @@ A plugin that adds a generic mechanism for tagging data.
                             }
                             else {
                                 return Collections.EMPTY_LIST                                                           
+                            }
+                        }
+                        findAllByTagsWithCriteria { List<String> names, Closure crit ->
+                            def clazz = delegate
+                            def identifiers = []
+                            names.each { name ->
+                                identifiers.addAll(TaggableGrailsPlugin.getTagReferences(tagService, name, clazz.name))
+                            }
+                            if(identifiers) {
+                                args.cache=true
+                                return clazz.withCriteria {
+                                    'in'('id', identifiers)
+
+                                    crit.delegate = delegate
+                                    crit.call()
+                                }
+                            }
+                            else {
+                                return Collections.EMPTY_LIST
                             }
                         }
                         findAllTagsWithCriteria { Map params, Closure criteria ->

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
 #Tue Sep 15 17:32:19 CEST 2015
-app.grails.version=2.5.1
+app.grails.version=2.5.4
 app.name=taggable

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Tue Nov 08 15:44:31 GMT 2011
-app.grails.version=2.3.8
+#Tue Sep 15 17:32:19 CEST 2015
+app.grails.version=2.5.1
 app.name=taggable

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -20,11 +20,11 @@ grails.project.dependency.resolution = {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
     }
     plugins {
-        build ':release:3.0.1', ':rest-client-builder:1.0.3', {
-            exported = false
+        build(":release:3.1.1", ":rest-client-builder:2.1.1") {
+            export = false
         }
 
-        runtime ":hibernate:3.6.10.14", {
+        runtime ":hibernate:3.6.10.19", {
             export = false
         }
     }

--- a/grails-app/services/org/grails/taggable/TaggableService.groovy
+++ b/grails-app/services/org/grails/taggable/TaggableService.groovy
@@ -1,14 +1,17 @@
 package org.grails.taggable
 
+import grails.transaction.NotTransactional
+import grails.transaction.Transactional
 import grails.util.*
 
 import org.grails.taggable.*
 
+@Transactional
 class TaggableService {
     
     def grailsApplication
     
-    def domainClassFamilies = [:]
+    private domainClassFamilies = [:]
     
     def getTagCounts(type) {
         def tagCounts = [:]
@@ -50,5 +53,10 @@ class TaggableService {
                 domainClassFamilies[artefact.clazz.name].addAll(artefact.subClasses.collect { GrailsNameUtils.getPropertyName(it.clazz) })
             }
         }
+    }
+
+    @NotTransactional
+    def getTaggablePropertyName(className) {
+        return domainClassFamilies[className]
     }
 }


### PR DESCRIPTION
Fixes #6 

This greatly improves the performances when getting tags in a row: on my computer, given 50 consecutive calls, the fix reduces the lookup time per call from 15 ms to 0 ms. The issue can add up to a several seconds penalty in a common use case (e.g. retrieving a hundred taggable elements through a REST API).

Other comments: 
* This should probably be ported to Grails 3.0
* All the tests pass on my machine
* I updated to Grails 2.5.1 and updated the dependencies accordingly
* I updated the plugin version to 1.1.2 (the plugin page http://grails.org/plugin/taggable shows a 1.1.1 release that I have never seen)